### PR TITLE
allow configuring extra containers as sidecar

### DIFF
--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -91,6 +91,7 @@ Gatus version is upgraded from 2 to 3. Gatus 3 deprecates `memory` type of stora
 | `nodeSelector`                            | Node labels for pod assignment                  | `{}`                                |
 | `tolerations`                             | Tolerations for pod assignment                  | `[]`                                |
 | `extraInitContainers`                     | Init containers to add to the gatus pod         | `[]`                                |
+| `extraContainers`                         | Containers to add to the gatus pod              | `[]`                                |
 | `persistence.enabled`                     | Use persistent volume to store data             | `false`                             |
 | `persistence.size`                        | Size of persistent volume claim                 | `200Mi`                             |
 | `persistence.mounthPath`                  | Persistent data volume's mount path             | `/data`                             |

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -57,7 +57,7 @@ containers:
         port: http
     {{- end }}
     resources:
-{{ toYaml .Values.resources | trim | indent 6 }}
+    {{ toYaml .Values.resources | trim | indent 6 }}
     volumeMounts:
       - name: {{ template "gatus.fullname" . }}-config
         mountPath: /config
@@ -75,6 +75,10 @@ containers:
         subPath: {{ .subPath | default "" }}
         readOnly: {{ .readOnly }}
     {{- end }}
+{{- if .Values.extraContainers }}
+initContainers:
+  {{- toYaml .Values.extraContainers | nindent 2 }}
+{{- end }}
 volumes:
   - name: {{ template "gatus.fullname" . }}-config
     configMap:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -128,8 +128,13 @@ tolerations: []
 # ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 extraInitContainers: []
   # - name: initializer
-    # image: busybox:latest
-    # command: ['sh', '-c', 'echo initialize the app before it starts']
+  #   image: busybox:latest
+  #   command: ['sh', '-c', 'echo initialize the app before it starts']
+
+# Additional containers (evaluated as template)
+extraContainers: []
+  # - name: initializer
+  #   image: nginx:latest
 
 # Enable persistence using Persistent Volume Claims
 # ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
Hi

It would be nice if I had the possibility to define additional containers to the deployment. 
Eg: a web interface to access the SQLite db directly.
This would helm me, as gatus by default limits the number of records returned by the database and I can not access older results, although they are kept for 7 days in the DB