### PR TITLE
Add way to specify ingress name and update README

### DIFF
--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -77,6 +77,8 @@ Gatus version is upgraded from 2 to 3. Gatus 3 deprecates `memory` type of stora
 | `service.annotations`                     | Service annotations                             | `{}`                                |
 | `service.labels`                          | Custom labels                                   | `{}`                                |
 | `ingress.enabled`                         | Enables Ingress                                 | `false`                             |
+| `ingress.ingressClassName`                | Ingress ClassName (for k8s 1.18+)               | ``                                  |
+| `ingress.name`                            | Ingress name                                    | ``                                  |
 | `ingress.annotations`                     | Ingress annotations (values are templated)      | `{}`                                |
 | `ingress.labels`                          | Custom labels                                   | `{}`                                |
 | `ingress.path`                            | Ingress accepted path                           | `/`                                 |

--- a/charts/gatus/templates/ingress.yaml
+++ b/charts/gatus/templates/ingress.yaml
@@ -10,7 +10,11 @@
 apiVersion: {{ include "gatus.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
+{{- if .Values.ingress.name }}
+  name: {{ .Values.ingress.name }}
+{{- else }}
   name: {{ $fullName }}
+{{- end }}
   namespace: {{ template "gatus.namespace" . }}
   labels:
     {{- include "gatus.labels" . | nindent 4 }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -71,6 +71,8 @@ ingress:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  #You can specify ingress name.
+  # name: "ingress-name"
   # Values can be templated
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Hi, 

I added a way to specify the ingress name. When I use certmanager annotation in order to generate tls certificate, the secrets created has the same name than the secret used by https://github.com/minicloudlabs/helm-charts/blob/main/charts/gatus/values.yaml#L116.

I don't edited secret to avoid breaking change

Thanks by advance.