### PR TITLE
gatus: add support for env[].valueFrom and envFrom

### DIFF
--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -33,8 +33,14 @@ containers:
     {{- if .Values.env }}
     env:
     {{- range $key, $value := .Values.env }}
+    {{- if kindIs "map" $value }}
+        - name: "{{ $key }}"
+          valueFrom:
+            {{- toYaml $value.valueFrom | nindent 12 }}
+    {{- else }}
         - name: "{{ $key }}"
           value: "{{ $value }}"
+    {{- end }}
     {{- end }}
     {{- end }}
     envFrom:
@@ -43,6 +49,9 @@ containers:
       {{- if .Values.secrets }}
       - secretRef:
           name: {{ include "common.names.fullname" . }}
+      {{- end }}
+      {{- if .Values.envFrom }}
+      {{- toYaml .Values.envFrom | nindent 6 }}
       {{- end }}
     {{- if .Values.readinessProbe.enabled }}
     readinessProbe:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -91,6 +91,16 @@ ingress:
 
 # Extra environment variables that will be pass onto deployment pods
 env: {}
+  # ENV_VAR_1: VALUE
+  # ENV_VAR_2:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: gatus-secret
+  #       key: secret
+
+envFrom: []
+  # - secretRef:
+  #     name: gatus-secret
 
 # Sidecar containers in the pod
 sidecarContainers: {}


### PR DESCRIPTION
This MR adds support for the env[].valueFrom syntax, allowing one to have Kubernetes Secrets made available to Gatus as environment variables.