### PR TITLE
Gatus: Add ability to use existing Secret in extraVolumeMounts list

### DIFF
--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -106,6 +106,9 @@ volumes:
     {{- else if .existingConfigMap }}
     configMap:
       name: {{ .existingConfigMap }}
+    {{- else if .existingSecret }}
+    secret:
+      secretName: {{ .existingSecret }}
     {{- else }}
     emptyDir: {}
     {{- end }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -111,6 +111,10 @@ extraVolumeMounts: []
   #   mountPath: /mnt/volume2
   #   readOnly: true
   #   existingConfigMap: config-map
+  # - name: extra-volume-3
+  #   mountPath: /mnt/volume3
+  #   readOnly: true
+  #   existingSecret: secret-name
 
 # Include secret's content in pods environment
 secrets: false

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -90,6 +90,8 @@ ingress:
   #      - gatus.local
 
 # Extra environment variables that will be pass onto deployment pods
+# Expects key: value
+# E.G. GATUS_CONFIG_PATH: /path/to/configs
 env: {}
 
 # Sidecar containers in the pod


### PR DESCRIPTION
This PR adds the ability to use an existing secret in the extraVolumeMounts list. An example of how to do this is in the values file, however its basically the same as using a configMap.

E.G.

```
  - name: extra-volume-3
    mountPath: /mnt/volume3
    readOnly: true
    existingSecret: secret-name
```

When specified, the volume for that list item will use secret.secretName.