### PR TITLE
fix: helm install failed when set '--name' field

### DIFF
--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -14,7 +14,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ## Install Chart
 
 ```console
-helm install --name [RELEASE_NAME] minicloudlabs/gatus
+helm install [RELEASE_NAME] minicloudlabs/gatus
 ```
 
 _See [configuration](#configuration) below._


### PR DESCRIPTION
Fix the install command: 
```
helm install --name gatus minicloudlabs/gatus --values values.yaml
Error: unknown flag: --name
```

helm version:
```
helm version
version.BuildInfo{Version:"v3.9.4", GitCommit:"dbc6d8e20fe1d58d50e6ed30f09a04a77e4c68db", GitTreeState:"clean", GoVersion:"go1.19"}
```