### PR TITLE
feat: support affinity

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
-version: 3.4.5
+version: 3.5.0
 appVersion: v5.11.0
 type: application
 engine: gotpl

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -93,6 +93,7 @@ Gatus version is upgraded from 2 to 3. Gatus 3 deprecates `memory` type of stora
 | `resources`                               | CPU/Memory resource requests/limits             | `{}`                                |
 | `nodeSelector`                            | Node labels for pod assignment                  | `{}`                                |
 | `tolerations`                             | Tolerations for pod assignment                  | `[]`                                |
+| `affinity`                                | Kubernetes affinity configuration               | `{}`                                |
 | `extraInitContainers`                     | Init containers to add to the gatus pod         | `[]`                                |
 | `persistence.enabled`                     | Use persistent volume to store data             | `false`                             |
 | `persistence.size`                        | Size of persistent volume claim                 | `200Mi`                             |

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -122,3 +122,7 @@ tolerations:
 {{ toYaml . | indent 2 }}
 {{- end }}
 {{- end }}
+{{- with .Values.affinity }}
+affinity:
+{{ toYaml . | indent 2 }}
+{{- end }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -137,6 +137,8 @@ nodeSelector: {}
 # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations: []
 
+affinity: {}
+
 # Additional init containers (evaluated as template)
 # ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 extraInitContainers: []


### PR DESCRIPTION
Hey there, I noticed the Chart doesn't support affinity yet. It would be a very useful feature for my local cluster (Spreading various Gatus replicas amongst my nodes), so I took the chance to contribute this small change.

Greetings!