### PR TITLE
Feat: Add Priorityclass for the gatus deployment.

### DIFF
--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -1,4 +1,7 @@
 {{- define "gatus.pod" -}}
+{{- if .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName | quote }}
+{{- end }}
 {{- if .Values.hostNetwork.enabled }}
 hostNetwork: true
 {{- end }}

--- a/charts/gatus/templates/deployment.yaml
+++ b/charts/gatus/templates/deployment.yaml
@@ -34,4 +34,8 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- include "gatus.pod" . | nindent 6 }}
+      

--- a/charts/gatus/templates/deployment.yaml
+++ b/charts/gatus/templates/deployment.yaml
@@ -35,4 +35,3 @@ spec:
         {{- end }}
     spec:
       {{- include "gatus.pod" . | nindent 6 }}
-      

--- a/charts/gatus/templates/deployment.yaml
+++ b/charts/gatus/templates/deployment.yaml
@@ -34,8 +34,5 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName | quote }}
-      {{- end }}
       {{- include "gatus.pod" . | nindent 6 }}
       

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -195,4 +195,4 @@ config:
 
 # Priority class name for the `Pod`.
 # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
-priorityClassName:
+priorityClassName: ""

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -192,3 +192,7 @@ config:
       conditions:
         - "[STATUS] == 200"
         - "[BODY] == pat(*<h1>Example Domain</h1>*)"
+
+# Priority class name for the `Pod`.
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+priorityClassName:


### PR DESCRIPTION
Hi there.

At the moment there is no priorityClassName integration for gatus.
Priorityclasses help to have a priority for pod deployments for the scheduler in case there is some cpu/memory pressure on worker nodes and you have mission critical applications.

See https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass.

I kindly ask to merge.